### PR TITLE
Google managed SSL cert

### DIFF
--- a/infra/.terraform.lock.hcl
+++ b/infra/.terraform.lock.hcl
@@ -22,21 +22,21 @@ provider "registry.terraform.io/hashicorp/google" {
   ]
 }
 
-provider "registry.terraform.io/hashicorp/random" {
-  version = "3.5.1"
+provider "registry.terraform.io/hashicorp/google-beta" {
+  version = "4.73.0"
   hashes = [
-    "h1:IL9mSatmwov+e0+++YX2V6uel+dV6bn+fC/cnGDK3Ck=",
-    "zh:04e3fbd610cb52c1017d282531364b9c53ef72b6bc533acb2a90671957324a64",
-    "zh:119197103301ebaf7efb91df8f0b6e0dd31e6ff943d231af35ee1831c599188d",
-    "zh:4d2b219d09abf3b1bb4df93d399ed156cadd61f44ad3baf5cf2954df2fba0831",
-    "zh:6130bdde527587bbe2dcaa7150363e96dbc5250ea20154176d82bc69df5d4ce3",
-    "zh:6cc326cd4000f724d3086ee05587e7710f032f94fc9af35e96a386a1c6f2214f",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:b6d88e1d28cf2dfa24e9fdcc3efc77adcdc1c3c3b5c7ce503a423efbdd6de57b",
-    "zh:ba74c592622ecbcef9dc2a4d81ed321c4e44cddf7da799faa324da9bf52a22b2",
-    "zh:c7c5cde98fe4ef1143bd1b3ec5dc04baf0d4cc3ca2c5c7d40d17c0e9b2076865",
-    "zh:dac4bad52c940cd0dfc27893507c1e92393846b024c5a9db159a93c534a3da03",
-    "zh:de8febe2a2acd9ac454b844a4106ed295ae9520ef54dc8ed2faf29f12716b602",
-    "zh:eab0d0495e7e711cca367f7d4df6e322e6c562fc52151ec931176115b83ed014",
+    "h1:cgwkp05LyBux6L0b2ll14AuJLunlZSsp0kcufECql/o=",
+    "zh:06f74cb22d37a4969c85db620b3314e896057c7675d9ce2c8d99bedad6821645",
+    "zh:120952bca69c8d77c6464c48dc27914e6052ec84d11ffd3bc882f96b54e9acae",
+    "zh:1ac1a20bdf9612286576f0f115d1b4f8a0ef993cd425859449a6c7bf440de186",
+    "zh:3c850a66ddff2670e0dc22f69820ebd7dce8d46eb681f6cf3a87b244f1ee0c54",
+    "zh:3ceecf4b66684e14c1cbf17457e24780cff57c8d8793e2a4e070b026f5dd7786",
+    "zh:5b47a292f5ad674d61c7f10dac07dadc11283436d86c264e2892cb1646b5b40c",
+    "zh:915ba988a4fb7674d035475452f44480def431531abeace03614803f85bc6b2c",
+    "zh:92940858ed81b653306303ad5bb88f5cb6ac46f66507dfbb4ca85b49dda2235b",
+    "zh:b8dff5dfe22848e8c78952442b8a3743ae833b8d694b856c53dda0e7abb4ca9d",
+    "zh:bc8a2d1945d45b789b18f832b8b07d12f89b77e53ee78477c0d91aead9f341a9",
+    "zh:cbfe25ad1329698cbec6a86f462b5e5494d68da5b74ebb71f5d9f321fc84ab37",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -22,7 +22,7 @@ resource "google_compute_network" "vpc" {
   name = "dpgraham-vpc"
 }
 
-resource "google_sql_database_instance" "staging" {
+resource "google_sql_database_instance" "dpgraham_postgres" {
   name             = "dpgraham-postgres"
   database_version = "POSTGRES_14"
   region           = var.region
@@ -41,11 +41,11 @@ resource "google_sql_database_instance" "staging" {
 
 resource "google_sql_database" "dpgraham_sql" {
   name     = "dpgraham"
-  instance = google_sql_database_instance.staging.name
+  instance = google_sql_database_instance.dpgraham_postgres.name
 }
 
 resource "google_sql_user" "users" {
-  instance = google_sql_database_instance.staging.name
+  instance = google_sql_database_instance.dpgraham_postgres.name
   type     = "BUILT_IN"
   name     = var.db_username
   password = var.db_password
@@ -104,4 +104,16 @@ resource "google_dns_record_set" "dpgraham_com_record_set" {
   rrdatas = [
     google_compute_instance.test_apache.network_interface[0].access_config[0].nat_ip
   ]
+}
+
+# google compute managed ssl certificate
+resource "google_compute_managed_ssl_certificate" "dpgraham_com" {
+  project     = var.project
+  provider    = google-beta
+  description = "Google managed SSL certificate for dpgraham.com"
+  name        = "dpgraham-ssl-cert"
+
+  managed {
+    domains = [var.domain_name]
+  }
 }

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -4,6 +4,12 @@ variable "project" {
   description = "The project ID"
 }
 
+variable "domain_name" {
+  description = "the top level domain of the project"
+  type        = string
+  default     = "dpgraham.com"
+}
+
 variable "region" {
   type        = string
   description = "The region to deploy to"


### PR DESCRIPTION
## Description
adds a google managed ssl certificate to our terraform configs
as described in the first part of this tutorial on the google docs
https://cloud.google.com/load-balancing/docs/ssl-certificates/google-managed-certs#gcloud_1


## Issue ticket number and link


