### PR TITLE
Publish gcp regsitry

### DIFF
--- a/.github/workflows/gcp-build-artifact.yaml
+++ b/.github/workflows/gcp-build-artifact.yaml
@@ -23,8 +23,11 @@ env:
   IMAGE_NAME: dpgraham-server
 
 jobs:
-  login-build-push:
-    name: Build and push to GCP
+  build-push:
+    environment: staging
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     runs-on: ubuntu-latest
 
     steps:
@@ -35,7 +38,7 @@ jobs:
         uses: docker/metadata-action@v4
         id: meta
         with:
-          images: ${{ GOOGLE_REGISTRY_LOCATION }}-docker.pkg.dev/${{ PROJECT_ID }}/${{ REPOSITORY }}/${{ IMAGE_NAME }}
+          images: ${{ env.GOOGLE_REGISTRY_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -43,24 +46,24 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha
 
-#      - name: Authenticate Google Cloud
-#        uses: google-github-actions/auth@v0
-#        id: auth
-#        with:
-#          credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
-#          token_format: 'access_token'
+      - name: Authenticate Google Cloud
+        uses: google-github-actions/auth@v1
+        id: auth
+        with:
+          credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
+          token_format: 'access_token'
 
-#      - name: Login to Google Artifact Registry
-#        uses: docker/login-action@v1
-#        with:
-#          registry: ${{ env.GOOGLE_REGISTRY_LOCATION }}-docker.pkg.dev
-#          username: 'oauth2accesstoken'
-#          password: '${{ steps.auth.outputs.access_token }}'
+      - name: Login to Google Artifact Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.GOOGLE_REGISTRY_LOCATION }}-docker.pkg.dev
+          username: 'oauth2accesstoken'
+          password: ${{ steps.auth.outputs.access_token }}
 
-      - name: Build
+      - name: Build and Push
         uses: docker/build-push-action@v3
         with:
           context: .
-          push: false
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/gcp-build-artifact.yaml
+++ b/.github/workflows/gcp-build-artifact.yaml
@@ -1,20 +1,18 @@
+# This Workflow builds and pushes a Docker image to Google Artifact Registry
+
+# Prerequisites:
 # 1. Create service account
-#.   * Service Account Token Creator
-#.   * Artifact Registry Writer
+#   1a. Service Account Token Creator
 # 2. Generate service account key
-#.   * In GitHub project -> Settings -> Secrets -> Actions -> New Repository Secret
-#.     Name: GCP_CREDENTIALS
-#.     Value: key.json contents
-# 3. Create repo in artifact repository
-#.   * Name: $env.REPOSITORY below
-#.   * Region: $env.GAR_LOCATION below
+#   2a. convert multiline key to single line with jq command (cat key.json | jq -r tostring)
+#   2b. create environment secret, Name: GOOGLE_CREDENTIALS, Value: key.json contents
+# 3. Make sure the Artifact repo has already been provisioned. Add to env:
 
 name: Docker build and push to Artifact Registry
 
 on:
-  push
-#  release:
-#    types: [published]
+  release:
+    types: [published]
 
 env:
   PROJECT_ID: dpgraham

--- a/.github/workflows/gcp-build-artifact.yaml
+++ b/.github/workflows/gcp-build-artifact.yaml
@@ -1,0 +1,66 @@
+# 1. Create service account
+#.   * Service Account Token Creator
+#.   * Artifact Registry Writer
+# 2. Generate service account key
+#.   * In GitHub project -> Settings -> Secrets -> Actions -> New Repository Secret
+#.     Name: GCP_CREDENTIALS
+#.     Value: key.json contents
+# 3. Create repo in artifact repository
+#.   * Name: $env.REPOSITORY below
+#.   * Region: $env.GAR_LOCATION below
+
+name: Docker build and push to Artifact Registry
+
+on:
+  push
+#  release:
+#    types: [published]
+
+env:
+  PROJECT_ID: dpgraham
+  GOOGLE_REGISTRY_LOCATION: us-east1
+  REPOSITORY: dpgraham-com
+  IMAGE_NAME: dpgraham-server
+
+jobs:
+  login-build-push:
+    name: Build and push to GCP
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Docker meta
+        uses: docker/metadata-action@v4
+        id: meta
+        with:
+          images: ${{ GOOGLE_REGISTRY_LOCATION }}-docker.pkg.dev/${{ PROJECT_ID }}/${{ REPOSITORY }}/${{ IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+
+#      - name: Authenticate Google Cloud
+#        uses: google-github-actions/auth@v0
+#        id: auth
+#        with:
+#          credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
+#          token_format: 'access_token'
+
+#      - name: Login to Google Artifact Registry
+#        uses: docker/login-action@v1
+#        with:
+#          registry: ${{ env.GOOGLE_REGISTRY_LOCATION }}-docker.pkg.dev
+#          username: 'oauth2accesstoken'
+#          password: '${{ steps.auth.outputs.access_token }}'
+
+      - name: Build
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,9 +8,9 @@ env:
   POSTGRES_DB: dpgraham_test
 
 on:
-#  push:
-#    branches:
-#      - '*'
+  push:
+    branches:
+      - '*'
   pull_request:
     branches:
       - 'main'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,9 +8,9 @@ env:
   POSTGRES_DB: dpgraham_test
 
 on:
-  push:
-    branches: 
-      - '*'
+#  push:
+#    branches:
+#      - '*'
   pull_request:
     branches:
       - 'main'

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -117,3 +117,10 @@ resource "google_compute_managed_ssl_certificate" "dpgraham_com" {
     domains = [var.domain_name]
   }
 }
+
+resource "google_artifact_registry_repository" "dpgraham_com" {
+  location      = var.region
+  repository_id = "dpgraham-com"
+  description   = "Repository for dpgraham.com"
+  format        = "DOCKER"
+}

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
 	"log"
+	"os"
 )
 
 // routerSetup returns a fully configured mux(?) with routes attached
@@ -31,8 +32,15 @@ func routerSetup() (router *gin.Engine) {
 
 // Entry point for the application
 func main() {
+	log.Printf("Starting server")
 	router := routerSetup()
-	err := router.Run(":8080")
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+		log.Printf("Defaulting to port %s", port)
+	}
+	log.Printf("Listening on port %s", port)
+	err := router.Run(":" + port)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
## Description

This PR adds a workflow to our main branch that builds and pushes images to the google artifact registry on release. 

We may exapnd the triggers to push more frequently if we start to roll out multiple environments, which for the purposes of this project seems like overkill. 

## Issue ticket number and link
fixes #11 

